### PR TITLE
Change selector to a CSS-style selector

### DIFF
--- a/JS/tei-documentation-links.js
+++ b/JS/tei-documentation-links.js
@@ -2,7 +2,7 @@
 if (typeof TEI_DOC_LINK === 'undefined') TEI_DOC_LINK = `xml tei-doc-link`;
 
 
-const codeList = document.getElementsByClassName(TEI_DOC_LINK);
+const codeList = document.querySelectorAll(TEI_DOC_LINK);
 //console.log(codeList);
 //console.log(codeList[0].textContent);
 


### PR DESCRIPTION
I changed one line of code, so that CSS-style selectors are possible. At least in my present use-case, this means I can use it in a Jekyll generated site where I cannot easily change the internal structure of the code samples to add the `xml`, `tei-doc-link` classes. I can then instead set `TEI_DOC_LINK` to `pre.highlight code`. 

Afaik there are no downsides, the only caveat: the list returned by `querySelectorAll()` is not live, as opposed to `getElementsByClassName`. (https://stackoverflow.com/a/26757629) You might know if that poses a problem (it doesn’t where I want to use it).